### PR TITLE
Use SYSTEM and not REBOL

### DIFF
--- a/latest-of.reb
+++ b/latest-of.reb
@@ -34,9 +34,9 @@ latest-of: function [os [tuple!]
 		commit: trim/tail to text! read to url! unspaced [https://dd498l1ilnrxu.cloudfront.net/travis-builds/ os %/last-deploy.short-hash]
 	]
 	root: https://dd498l1ilnrxu.cloudfront.net/travis-builds/
-	; commit: copy/part rebol/commit 7
+	; commit: copy/part system/commit 7
 	digit: charset [#"0" - #"6"]
-	inf?: if find form rebol/version "2.102.0.16.2" [
+	inf?: if find form system/version "2.102.0.16.2" [
 		web: true
 		fsize-of: function [o [object!]][to integer! o/content-length]
 		fdate-of: function [o [object!]][


### PR DESCRIPTION
The historical equivalence between SYSTEM and REBOL is no longer.  The reason
is because it was deceptive when you would say `do [rebol [Type: 'Module] ...]`
or otherwise have header information there.  This could only be processed if a
LOAD was performed, e.g. if you used text like `do "rebol [Type 'Module] ..."`.
If the code was already loaded, what was actually happening was that your
object reference to `rebol` was evaluated and thrown away, then the BLOCK!
of your header information would be evaluated and thrown away.

Accordingly, Rebol has been made an error, informing you of this mistake...
that no LOAD-ed code should actually be executing a Rebol header signal.